### PR TITLE
Update how-to-build-cppnamelint.md

### DIFF
--- a/doc/how-to-build-cppnamelint.md
+++ b/doc/how-to-build-cppnamelint.md
@@ -37,7 +37,7 @@ Attention! before continue, this project is based on LLVM's libtooling library, 
 
 ### Linux
    1. `$ cd cpp-namelint.git/script`  
-   1. `$ build-pack-linux.sh`
+   1. `$ build-bin-linux.sh`
    1. `$ cd cpp-namelint.git/build/linux`
    1. `$ make`
 

--- a/doc/how-to-build-cppnamelint.md
+++ b/doc/how-to-build-cppnamelint.md
@@ -37,7 +37,7 @@ Attention! before continue, this project is based on LLVM's libtooling library, 
 
 ### Linux
    1. `$ cd cpp-namelint.git/script`  
-   1. `$ build-bin-linux.sh`
+   1. `$ build-bin-linux.sh` 
    1. `$ cd cpp-namelint.git/build/linux`
    1. `$ make`
 


### PR DESCRIPTION
Fixed typo for Linux.
`$ build-pack-linux.sh` --> `$ build-bin-linux.sh`