### PR TITLE
Use find_package() function in CMakeLists.txt to find related library…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,26 +1,67 @@
+#===----------------------------------------------------------------------===#
+#                           The MIT License (MIT)
+#             Copyright (c) 2020 Douglas Chen <dougpuob@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#===----------------------------------------------------------------------===#
 cmake_minimum_required(VERSION 3.10)
 project(cppnamelint)
-
 
 set(CMAKE_CXX_STANDARD          17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS        OFF)
 
-
-###############################################################################
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-    set (BUILD_TYPE Debug)
-elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-    set (BUILD_TYPE Release)
-elseif(CMAKE_BUILD_TYPE STREQUAL RelWithDebInfo)
-    set (BUILD_TYPE RelWithDebInfo)
-else()
-    set (BUILD_TYPE release)
-endif()
+message(STATUS "CMAKE_CURRENT_SOURCE_DIR : ${CMAKE_CURRENT_SOURCE_DIR}"  )
+message(STATUS "CMAKE_BUILD_TYPE         : ${CMAKE_BUILD_TYPE}"          )
+message(STATUS "CMAKE_SYSTEM             : ${CMAKE_SYSTEM}"              )
+message(STATUS "CMAKE_SYSTEM_NAME        : ${CMAKE_SYSTEM_NAME}"         )
+message(STATUS "CMAKE_SYSTEM_VERSION     : ${CMAKE_SYSTEM_VERSION}"      )
+message(STATUS "CMAKE_SYSTEM_PROCESSOR   : ${CMAKE_SYSTEM_PROCESSOR}"    )
 
 
 ###############################################################################
-if(WIN32)
+# LLVM libraries
+###############################################################################
+find_package(LLVM  REQUIRED CONFIG PATHS ${LLVM_INSTALL_DIR} NO_DEFAULT_PATH)
+find_package(Clang REQUIRED CONFIG PATHS ${LLVM_INSTALL_DIR} NO_DEFAULT_PATH)
+
+include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${CLANG_INCLUDE_DIRS})
+
+add_definitions(${LLVM_DEFINITIONS})
+add_definitions(${CLANG_DEFINITIONS})
+
+llvm_map_components_to_libnames(LLVM_LIBS core clang native support irreader)
+message(STATUS "LLVM_INSTALL_DIR         : ${LLVM_INSTALL_DIR}")
+message(STATUS "CLANG_INCLUDE_DIRS       : ${CLANG_INCLUDE_DIRS}")
+message(STATUS "LLVM_INCLUDE_DIRS        : ${LLVM_INCLUDE_DIRS}")
+message(STATUS "LLVM_LIBRARY_DIRS        : ${LLVM_LIBRARY_DIRS}")
+message(STATUS "LLVM_PACKAGE_VERSION     : ${LLVM_PACKAGE_VERSION}")
+message(STATUS "LLVM_DIR                 : ${LLVM_DIR}")
+message(STATUS "LLVM_CMAKE_PATH          : ${LLVM_CMAKE_PATH}")
+message(STATUS "LLVM_DEFINITIONS         : ${LLVM_DEFINITIONS}")
+
+###############################################################################
+# This project
+###############################################################################
+if(CMAKE_HOST_WIN32)
+    set(OUTPUT_OS "windows")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4141")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4146")
@@ -30,102 +71,28 @@ if(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4996")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4477")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /source-charset:utf-8")
+    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /source-charset:utf-8")
     set(gtest_force_shared_crt ON CACHE BOOL "Always use msvcrt.dll" )
-elseif(UNIX AND NOT APPLE)
-    set(CC   "/usr/bin/gcc")
-    set(CXX  "/usr/bin/g++")
-    string(TOLOWER ${BUILD_TYPE} BUILD_TYPE)
-    set(CMAKE_CXX_FLAGS "-frtti -g")
-elseif(APPLE)
-    set(CC   "/usr/bin/clang")
-    set(CXX  "/usr/bin/clang++")
-    string(TOLOWER ${BUILD_TYPE} BUILD_TYPE)
-    set(CMAKE_CXX_FLAGS "-frtti")
-endif()
-
-
-###############################################################################
-set(LLVM_DIR_CPPNAMELINT_PATH $ENV{LLVM_DIR_CPPNAMELINT}/build/${BUILD_TYPE}/lib)
-if(WIN32)
     set(EXTERNAL_LIB Version)
-elseif(UNIX AND NOT APPLE)
-    set(EXTERNAL_LIB z tinfo)
-elseif(APPLE)
-    set(EXTERNAL_LIB z ncurses)
-endif()
-
-
-###############################################################################
-include_directories(
-    $ENV{LLVM_DIR_CPPNAMELINT}/llvm/include
-    $ENV{LLVM_DIR_CPPNAMELINT}/clang/include
-    $ENV{LLVM_DIR_CPPNAMELINT}/build/include
-    $ENV{LLVM_DIR_CPPNAMELINT}/build/tools/clang/include
-    $ENV{LLVM_DIR_CPPNAMELINT}/build/${BUILD_TYPE}/include
-    $ENV{LLVM_DIR_CPPNAMELINT}/build/${BUILD_TYPE}/tools/clang/include
-    $ENV{LLVM_DIR_CPPNAMELINT}/build/${BUILD_TYPE}/tools/llvm/include
-    submodule/googletest.git/googletest/include
-    submodule/json.git/include
-)
-
-link_directories(${LLVM_DIR_CPPNAMELINT_PATH})
-
-
-###############################################################################
-message("CMAKE_CURRENT_SOURCE_DIR   : ${CMAKE_CURRENT_SOURCE_DIR}"  )
-message("CMAKE_BUILD_TYPE           : ${CMAKE_BUILD_TYPE}"          )
-message("CMAKE_SYSTEM               : ${CMAKE_SYSTEM}"              )
-message("CMAKE_SYSTEM_NAME          : ${CMAKE_SYSTEM_NAME}"         )
-message("CMAKE_SYSTEM_VERSION       : ${CMAKE_SYSTEM_VERSION}"      )
-message("CMAKE_SYSTEM_PROCESSOR     : ${CMAKE_SYSTEM_PROCESSOR}"    )
-
-if(WIN32)
-    message("Platform                   : WIN32" )
-elseif(UNIX AND NOT APPLE)
-    message("Platform                   : UNIX AND NOT APPLE" )
-elseif(APPLE)
-    message("Platform                   : APPLE" )
-else()
-    message("Platform                   : ERROR HERE" )
-endif()
-
-message("BUILD_TYPE                 : ${BUILD_TYPE}")
-message("LLVM_DIR_CPPNAMELINT       : $ENV{LLVM_DIR_CPPNAMELINT}")
-message("LLVM_DIR_CPPNAMELINT_PATH  : ${LLVM_DIR_CPPNAMELINT_PATH}" )
-#message("CMAKE_CXX_FLAGS           : ${CMAKE_CXX_FLAGS}" )
-message("INC_PATH_1                 : $ENV{LLVM_DIR_CPPNAMELINT}/llvm/include" )
-message("INC_PATH_2                 : $ENV{LLVM_DIR_CPPNAMELINT}/clang/include" )
-message("INC_PATH_3                 : $ENV{LLVM_DIR_CPPNAMELINT}/build/${BUILD_TYPE}/include" )
-message("INC_PATH_4                 : $ENV{LLVM_DIR_CPPNAMELINT}/build/${BUILD_TYPE}/tools/clang/include" )
-message("INC_PATH_5                 : $ENV{LLVM_DIR_CPPNAMELINT}/build/${BUILD_TYPE}/tools/llvm/include" )
-
-
-###############################################################################
-option(BUILD_TESTING "Turn OFF to build the testing tree (json)." OFF)
-
-add_subdirectory(submodule/googletest.git)
-add_subdirectory(submodule/json.git)
-
-
-###############################################################################
-set(OUTPUT_OS "")
-if(WIN32)
-    set(OUTPUT_OS "windows")
-elseif(UNIX AND NOT APPLE)
-    set(OUTPUT_OS "linux")
-elseif(APPLE)
+elseif(CMAKE_HOST_APPLE)
     set(OUTPUT_OS "macos")
-else()
-    set(OUTPUT_OS "error")
+    #set(CC   "/usr/bin/clang")
+    #set(CXX  "/usr/bin/clang++")
+    set(CMAKE_CXX_FLAGS "-frtti")
+    set(EXTERNAL_LIB z ncurses)
+elseif(CMAKE_HOST_UNIX)
+    set(OUTPUT_OS "linux")
+    #set(CC   "/usr/bin/gcc")
+    #set(CXX  "/usr/bin/g++")
+    set(CMAKE_CXX_FLAGS "-fno-rtti -g")
+    set(EXTERNAL_LIB z tinfo)
 endif()
 
+# Output folders
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/build/${OUTPUT_OS}/output)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/build/${OUTPUT_OS}/output)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/build/${OUTPUT_OS}/output)
 
-
-###############################################################################
 add_executable(
     cppnamelint
     submodule/tinytoml.git/include/toml/toml.h
@@ -165,141 +132,26 @@ add_executable(
     source/test/TestRunCheck_CppStruct.cpp
 )
 
+include_directories(
+    submodule/json.git/include
+    submodule/googletest.git/googletest/include
+)
 
-###############################################################################
 target_link_libraries(
     cppnamelint
-    #------------------------#
-    # Submodules             #
-    #------------------------#
     gtest
     gtest_main
-    #------------------------#
-    # LLVM's libraries       #
-    #------------------------#
-    LLVMBinaryFormat
-    LLVMBitReader
-    LLVMCore
-    LLVMDemangle
-    LLVMMC
-    LLVMProfileData
-    LLVMOption
-    LLVMMCParser
-    LLVMSupport
-    LLVMCore
-    clangTooling
-    clangAnalysis
-    clangSerialization
-    clangParse
-    clangDriver
-    clangSema
-    clangEdit
-    clangFrontend
-    clangAST
-    clangLex
-    clangBasic
-    clangAnalysis
-    clangARCMigrate
-    clangAST
-    clangASTMatchers
-    clangBasic
-    clangCodeGen
-    clangCrossTU
-    clangDriver
-    clangDynamicASTMatchers
-    clangEdit
-    clangFormat
-    clangFrontend
-    clangFrontendTool
-    clangHandleCXX
-    clangHandleLLVM
-    clangIndex
-    clangLex
-    clangParse
-    clangRewrite
-    clangRewriteFrontend
-    clangSema
-    clangSerialization
-    clangStaticAnalyzerCheckers
-    clangStaticAnalyzerCore
-    clangStaticAnalyzerFrontend
-    clangTooling
-    clangToolingASTDiff
-    clangToolingCore
-    clangToolingInclusions
-    clangToolingRefactor
-    LLVMAggressiveInstCombine
-    LLVMAnalysis
-    LLVMAsmParser
-    LLVMAsmPrinter
-    LLVMBinaryFormat
-    LLVMBitReader
-    LLVMBitWriter
-    LLVMCodeGen
-    LLVMCore
-    LLVMCoroutines
-    LLVMCoverage
-    LLVMDebugInfoCodeView
-    LLVMDebugInfoDWARF
-    LLVMDebugInfoMSF
-    LLVMDebugInfoPDB
-    LLVMDemangle
-    LLVMDlltoolDriver
-    LLVMExecutionEngine
-    LLVMFuzzMutate
-    LLVMGlobalISel
-    LLVMInstCombine
-    LLVMInstrumentation
-    LLVMInterpreter
-    LLVMipo
-    LLVMIRReader
-    LLVMLibDriver
-    LLVMLineEditor
-    LLVMLinker
-    LLVMLTO
-    LLVMMC
-    LLVMMCDisassembler
-    LLVMMCJIT
-    LLVMMCParser
-    LLVMObjCARCOpts
-    LLVMObject
-    LLVMObjectYAML
-    LLVMOption
-    LLVMOrcJIT
-    LLVMPasses
-    LLVMProfileData
-    LLVMRuntimeDyld
-    LLVMScalarOpts
-    LLVMSelectionDAG
-    LLVMSupport
-    LLVMSymbolize
-    LLVMTableGen
-    LLVMTarget
-    LLVMTestingSupport
-    LLVMTransformUtils
-    LLVMVectorize
-    LLVMWindowsManifest
-    LLVMX86AsmParser
-    LLVMX86AsmPrinter
-    LLVMX86CodeGen
-    LLVMX86Desc
-    LLVMX86Disassembler
-    LLVMX86Info
-    LLVMXRay
-    LTO
-    clangParse
-    clangSerialization
-    clangDriver
-    clangIndex
-    clangSema
-    clangAnalysis
-    clangAST
-    clangFrontend
-    clangEdit
-    clangLex
-    clangBasic
-    LLVMSupport
-    LLVMCore
-    LLVMMC
-    ${EXTERNAL_LIB}
+    ${LLVM_AVAILABLE_LIBS}      # Defined in LLVMConfig.cmake file.
+    ${CLANG_EXPORTED_TARGETS}   # Defined in ClangConfig.cmake file.
+    ${EXTERNAL_LIB}             # Defined in this project.
 )
+
+
+###############################################################################
+# Third-party libraries
+###############################################################################
+option(BUILD_TESTING "Turn OFF to build the testing tree (json)." OFF)
+
+add_subdirectory(submodule/googletest.git)
+add_subdirectory(submodule/json.git)
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,11 +10,6 @@ jobs:
   #==============================================================================
   - job: BuildOnWindows
 
-    variables:
-      - name: LLVM_DIR_CPPNAMELINT
-        value: $(System.DefaultWorkingDirectory)\llvm_8_0_0_msvc2019_rel_64bit
-      - name: BUILD_TYPE
-        value: Release
 
     pool:
       vmImage: "windows-2019"
@@ -30,28 +25,26 @@ jobs:
       - task: UniversalPackages@0
         inputs:
           command: 'download'
-          downloadDirectory: '$(System.DefaultWorkingDirectory)'
+          downloadDirectory: '$(System.DefaultWorkingDirectory)\llvmorg-11.1.0-prebuilt-library'
           feedsToUse: 'internal'
-          vstsFeed: '78202891-aba0-41ab-952b-2152c4a57470/6c9732cf-3246-4264-adef-0269b29710c6'
-          vstsFeedPackage: '37f4150c-328c-49cb-ba1d-a44eaea25fad'
+          vstsFeed: 'fda65372-3b82-4cc7-9460-941932f2b9e1/cc48bf99-5156-4bd9-bcae-9f312d30c074'
+          vstsFeedPackage: '04bd13f9-2b8a-49da-a498-d272add210f2'
           vstsPackageVersion: '0.0.1'
           verbosity: 'Trace'
-          
-      - task: PowerShell@2
-        inputs:
-          filePath: 'script/build-bin-win32.ps1'
-          workingDirectory: 'script'
 
-      - task: MSBuild@1
+      - task: CMake@1
         inputs:
-          solution: "build/windows/cppnamelint.sln"
-          msbuildVersion: "16.0"
-          configuration: "Release"
-          msbuildArchitecture: "x64" #x86, x64
-          
+          workingDirectory: 'build\windows'
+          cmakeArgs: '..\.. -DLLVM_INSTALL_DIR=$(System.DefaultWorkingDirectory)\llvmorg-11.1.0-prebuilt-library'
+
+      - task: CMake@1
+        inputs:
+          workingDirectory: 'build\windows'
+          cmakeArgs: '--build . --config Release'
+
       - task: PowerShell@2
         inputs:
-          filePath: 'script/build-pack-win32.ps1'
+          filePath: 'script\build-pack-win32.ps1'
           workingDirectory: 'script'
 
       - task: ArchiveFiles@2
@@ -63,9 +56,14 @@ jobs:
           replaceExistingArchive: true
           verbose: true
 
+      - task: PowerShell@2
+        inputs:
+          filePath: 'script/run-test-win32.ps1'
+          workingDirectory: 'script/release/windows'
+
       - task: GitHubRelease@1
         inputs:
-          gitHubConnection: 'github.com_dougpuob'
+          gitHubConnection: 'azure-devops-cppnamelint'
           repositoryName: 'dougpuob/cppnamelint'
           action: 'edit'
           target: '$(Build.SourceVersion)'
@@ -77,22 +75,12 @@ jobs:
           changeLogCompareToRelease: 'lastFullRelease'
           changeLogType: 'issueBased'
 
-      - task: PowerShell@2
-        inputs:
-          filePath: 'script/run-test-win32.ps1'
-          workingDirectory: 'script/release/windows'
-
-          
   #==============================================================================
   # Linux
   #==============================================================================
   - job: BuildOnLinux
 
     variables:
-      - name: LLVM_DIR_CPPNAMELINT
-        value: $(System.DefaultWorkingDirectory)/llvm_8_0_0_ubuntu_18_04_gcc_7_4_rel_64bit
-      - name: BUILD_TYPE
-        value: Release
       - name: CC
         value: gcc
       - name: CXX
@@ -114,24 +102,35 @@ jobs:
 
       - task: UniversalPackages@0
         inputs:
-          command: "download"
-          downloadDirectory: "$(System.DefaultWorkingDirectory)"
-          feedsToUse: "internal"
-          vstsFeed: "78202891-aba0-41ab-952b-2152c4a57470/1d266e96-42a9-4468-83b0-69b039e87cb3"
-          vstsFeedPackage: "e8febc2a-50f8-4b36-832d-87feb38f96f0"
-          vstsPackageVersion: "0.0.2"
-          verbosity: "Trace"
+          command: 'download'
+          downloadDirectory: '$(System.DefaultWorkingDirectory)/llvmorg-11.1.0-prebuilt-library'
+          feedsToUse: 'internal'
+          vstsFeed: 'fda65372-3b82-4cc7-9460-941932f2b9e1/0e415509-a02b-46c9-9a2e-53aaa5cce17e'
+          vstsFeedPackage: '15a1cdaa-9842-4471-805d-6d3fec90be8f'
+          vstsPackageVersion: '0.0.1'
+          verbosity: 'Trace'
+      
       - script: "ls -la"
+
+      - task: CMake@1
+        inputs:
+          workingDirectory: 'build/linux'
+          cmakeArgs: '../.. -DLLVM_INSTALL_DIR=$(System.DefaultWorkingDirectory)/llvmorg-11.1.0-prebuilt-library'
+
+      - task: CMake@1
+        inputs:
+          workingDirectory: 'build/linux'
+          cmakeArgs: '--build . --config Release'
 
       #- script: "ls -la -R"
       #  displayName: "Dump folder hierarchy"
 
-      - script: "./build-bin-linux.sh"
-        displayName: "build-bin-linux.sh"
-        workingDirectory: "script"
+      # - script: "./build-bin-linux.sh"
+      #   displayName: "build-bin-linux.sh"
+      #   workingDirectory: "script"
 
-      - script: make
-        workingDirectory: "build/linux"
+      # - script: make
+      #   workingDirectory: "build/linux"
 
       #- script: "ls -la -R"
       #  displayName: "Dump folder hierarchy"
@@ -152,9 +151,13 @@ jobs:
           replaceExistingArchive: true
           verbose: true
 
+      - script: "./run-test-linux.sh"
+        displayName: "run-test-linux.sh"
+        workingDirectory: "script/release/linux"
+      
       - task: GitHubRelease@1
         inputs:
-          gitHubConnection: 'github.com_dougpuob'
+          gitHubConnection: 'azure-devops-cppnamelint'
           repositoryName: 'dougpuob/cppnamelint'
           action: 'edit'
           target: '$(Build.SourceVersion)'
@@ -167,86 +170,80 @@ jobs:
           changeLogType: 'issueBased'
 
 
-      - script: "./run-test-linux.sh"
-        displayName: "run-test-linux.sh"
-        workingDirectory: "script/release/linux"
+  # Remove it temparately becuase my MacPro is newer than Azure runner.
+  # #==============================================================================
+  # # macOS ("macOS-10.15")
+  # #==============================================================================
+  # - job: BuildOnMacOS
 
+  #   variables:
+  #     - name: CC
+  #       value: clang
+  #     - name: CXX
+  #       value: clang++
 
-  #==============================================================================
-  # macOS ("macOS-10.14")
-  #==============================================================================
-  - job: BuildOnMacOS
+  #   pool:
+  #     vmImage: "macOS-10.15"
 
-    variables:
-      - name: LLVM_DIR_CPPNAMELINT
-        value: $(System.DefaultWorkingDirectory)/llvm_8_0_0_macos_10_14_5_clang_10_rel_64bit
-      - name: BUILD_TYPE
-        value: Release
-      - name: CC
-        value: clang
-      - name: CXX
-        value: clang++
+  #   steps:
+  #     - script: "clang --version"
+  #       displayName: "Show gcc version."
 
-    pool:
-      vmImage: "macOS-10.14"
+  #     - script: "export"
+  #       displayName: "Dump Azure environment variables."
 
-    steps:
-      - script: "clang --version"
-        displayName: "Show gcc version."
+  #     - checkout: self
+  #       displayName: "Checkout git submodules."
+  #       submodules: true
 
-      - script: "export"
-        displayName: "Dump Azure environment variables."
+  #     - task: UniversalPackages@0
+  #       inputs:
+  #         command: 'download'
+  #         downloadDirectory: '$(System.DefaultWorkingDirectory)/llvmorg-11.1.0-prebuilt-library'
+  #         feedsToUse: 'internal'
+  #         vstsFeed: 'fda65372-3b82-4cc7-9460-941932f2b9e1/1a38fd81-aa9c-4d52-994e-4166c8467c06'
+  #         vstsFeedPackage: 'ffae4614-057b-4495-8689-e11543edb830'
+  #         vstsPackageVersion: '0.0.1'
+  #         verbosity: 'Trace'
 
-      - checkout: self
-        displayName: "Checkout git submodules."
-        submodules: true
+  #     - task: CMake@1
+  #       inputs:
+  #         workingDirectory: 'build/macos'
+  #         cmakeArgs: '../.. -DLLVM_INSTALL_DIR=$(System.DefaultWorkingDirectory)/llvmorg-11.1.0-prebuilt-library'
 
-      - task: UniversalPackages@0
-        inputs:
-          command: "download"
-          downloadDirectory: "$(System.DefaultWorkingDirectory)"
-          feedsToUse: "internal"
-          vstsFeed: "78202891-aba0-41ab-952b-2152c4a57470/7bc16282-7635-45e1-821a-373ed55c68c5"
-          vstsFeedPackage: "1ea8f4a8-0c01-4eb1-8fbf-e514f8768b5e"
-          vstsPackageVersion: "0.0.1"
-          verbosity: "Trace"
+  #     - task: CMake@1
+  #       inputs:
+  #         workingDirectory: 'build/macos'
+  #         cmakeArgs: '--build . --config Release'
 
-      - task: Bash@3
-        inputs:
-          filePath: 'script/build-bin-macos.sh'
-          workingDirectory: 'script'
+  #     - task: Bash@3
+  #       inputs:
+  #         filePath: 'script/build-pack-linux.sh'
+  #         workingDirectory: 'script'
 
-      - script: make
-        workingDirectory: "build/macos"
-
-      - task: Bash@3
-        inputs:
-          filePath: 'script/build-pack-linux.sh'
-          workingDirectory: 'script'
-
-      - task: ArchiveFiles@2
-        inputs:
-          rootFolderOrFile: 'script/release/macos'
-          includeRootFolder: false
-          archiveType: 'zip'
-          archiveFile: 'cppnamelint-macos-10.14.7z'
-          replaceExistingArchive: true
-          verbose: true
+  #     - task: ArchiveFiles@2
+  #       inputs:
+  #         rootFolderOrFile: 'script/release/macos'
+  #         includeRootFolder: false
+  #         archiveType: 'zip'
+  #         archiveFile: 'cppnamelint-macos-10.14.7z'
+  #         replaceExistingArchive: true
+  #         verbose: true
           
-      - script: "./run-test-linux.sh"
-        displayName: "run-test-linux.sh"
-        workingDirectory: "script/release/macos"
+  #     - script: "./run-test-linux.sh"
+  #       displayName: "run-test-linux.sh"
+  #       workingDirectory: "script/release/macos"
 
-      - task: GitHubRelease@1
-        inputs:
-          gitHubConnection: 'github.com_dougpuob'
-          repositoryName: 'dougpuob/cppnamelint'
-          action: 'edit'
-          target: '$(Build.SourceVersion)'
-          tag: 'v0.3*'
-          assets: 'cppnamelint-macos-10.14.7z'
-          assetUploadMode: 'replace'
-          isDraft: true
-          isPreRelease: true
-          changeLogCompareToRelease: 'lastFullRelease'
-          changeLogType: 'issueBased'
+  #     # - task: GitHubRelease@1
+  #     #   inputs:
+  #     #     gitHubConnection: 'github.com_dougpuob'
+  #     #     repositoryName: 'dougpuob/cppnamelint'
+  #     #     action: 'edit'
+  #     #     target: '$(Build.SourceVersion)'
+  #     #     tag: 'v0.3*'
+  #     #     assets: 'cppnamelint-macos-10.14.7z'
+  #     #     assetUploadMode: 'replace'
+  #     #     isDraft: true
+  #     #     isPreRelease: true
+  #     #     changeLogCompareToRelease: 'lastFullRelease'
+  #     #     changeLogType: 'issueBased'

--- a/doc/how-to-build-cppnamelint.md
+++ b/doc/how-to-build-cppnamelint.md
@@ -1,51 +1,49 @@
-# How to build Cpp-NameLint (This project)
+# How to build CppNameLint (This project)
 
-This project is integrated with Azure DevOps, so you can read `azure-pipelines.yml` to now how to build. Another way is read the following content.
+This project is based on LLVM's libtooling library, so you have to build llvm first. Then it uses CMake's find_package() function to find LLVM library, this means you don't need to specific libraries in CMakeLists.txt file, all depend on `LLVMConfig.cmake` and `ClangConfig.cmake` files.
 
-Attention! before continue, this project is based on LLVM's libtooling library, so you have prepare library binary files for it. There are two ways:
-1. Download from my cloud (contact me, I will send you the links. I will pack it later because I am planing to use `LLVMConfig.cmake`)
-2. Build LLVM youself. (how-to-build-llvm.md)
+Understand it more details, please read `CMakeLists.txt` and `azure-pipelines.yml`.
  
 ➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖
 ## Requires Common Tools
 
 1. git
 2. cmake
-3. python3
-4. Compilers
-    - Windows: Visual Studio 2017 Community
-    - Linux : gcc-8
-    - MacOS : llvm-8
+3. ninja
+4. python3
+5. Compilers
+    - Windows: Visual Studio 2019 Community
+    - Linux : gcc
+    - MacOS : clang
 
-➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖
-## Prepare essentials
-
-1. **Git clone project to your local**
-`$ git clone https://github.com/dougpuob/cpp-namelint.git cpp-namelint.git`
-
-2. **Set environment variable**  
-   - **Windows** : $ SET LLVM_DIR_CPPNAMELINT    "C:\llvm-project.git"
-   - **Linux**   : $ export LLVM_DIR_CPPNAMELINT "~/llvm-project.git"
-   - **macOS**   : $ export LLVM_DIR_CPPNAMELINT "~/llvm-project.git"
 
 ➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖
 ## Build this project
 ### Windows
-   1. `$ cd cpp-namelint.git/script`  
-   1. `$ powershell.exe "./build-bin-win32.ps1"` or `./build-bin-win32-dbg.ps1"` for debugging.  
-   1. Launch & build `build\windows\cppnamelint.sln`.
+``` powershell
+git clone https://github.com/dougpuob/cpp-namelint.git cppnamelint.git
+cd cppnamelint.git
+git submodule init
+git submodule update
 
-### Linux
-   1. `$ cd cpp-namelint.git/script`  
-   1. `$ build-bin-linux.sh` 
-   1. `$ cd cpp-namelint.git/build/linux`
-   1. `$ make`
+mkdir build
+cd build
+cmake .. -DLLVM_INSTALL_DIR="C:\petzone\llvm\llvm-prebuilt\llvmorg-11.1.0-msbuild-vs2019-x64-rel"
+cmake --build . --config Release
+```
 
-### macOS
-   1. `$ cd cpp-namelint.git/script`  
-   1. `$ build-bin-macos.sh`
-   1. `$ cd cpp-namelint.git/build/macos`
-   1. `$ make`
+### Linux & macOS
+``` bash
+git clone https://github.com/dougpuob/cpp-namelint.git cppnamelint.git
+cd cppnamelint.git
+git submodule init
+git submodule update
+
+mkdir build
+cd build
+cmake .. -DLLVM_INSTALL_DIR="~\llvm\llvm-prebuilt\llvmorg-11.1.0-ninja-gcc-x64-rel"
+cmake --build . --config Release
+```
 
 ➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖
 ## Pack & Test this project

--- a/doc/how-to-build-llvm.md
+++ b/doc/how-to-build-llvm.md
@@ -6,11 +6,12 @@
 
 1. git
 2. cmake
-3. python3
-4. Compilers
-    - Windows: Visual Studio 2017 Community
-    - Linux : gcc-8
-    - MacOS : llvm-8
+3. ninja
+4. python3
+5. Compilers
+    - Windows: Visual Studio 2019 Community
+    - Linux : gcc
+    - MacOS : clang
 
 ➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖
 
@@ -22,61 +23,45 @@
 ``` sh
 $ git clone [https://github.com/llvm/llvm-project.git](https://github.com/llvm/llvm-project.git) llvm-project.git
 $ cd llvm-project.git
-$ git checkout llvmorg-8.0.0
-
-# Do the following with Release build
-$ mkdir -p build/release
-$ cd build/release
-
-# Do the following with Debug build
-$ mkdir -p build/debug
-$ cd build/debug
+$ git checkout llvmorg-11.1.0
+$ mkdir -p build
 ```
 
 ### 2. Build for Windows
 
-``` sh
-################################################################################
-# Release                                                                      #
-################################################################################
-# 32-bit (VS2017)
-$ cmake -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 15 2017" -Thost=x64 ..\llvm
+``` powershell
+# Config
+cmake -G "Visual Studio 16 2019" -A X64                         `
+      -DLLVM_ENABLE_ABI_BREAKING_CHECKS=OFF                     `
+      -DLLVM_TARGETS_TO_BUILD="X86"                             `
+      -DLLVM_ENABLE_PROJECTS="clang;llvm;clang-tools-extra"     `
+      -DCMAKE_BUILD_TYPE=Release                                `
+      -DCMAKE_INSTALL_PREFIX="C:\petzone\llvm\llvm-prebuilt\llvmorg-11.1.0-msbuild-vs2019-x64-rel"    `
+      ../llvm
 
-# 64-bit (VS2017)
-$ cmake -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 15 2017" -A x64 -Thost=x64 ..\llvm
+# Make
+cmake --build . --config Release
 
-# 64-bit (VS2019)
-$ cmake -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 16 2019" -A x64 -Thost=x64 ..\llvm
-
-################################################################################
-# Debug                                                                        #
-################################################################################
-# 32-bit (VS2017)
-$ cmake -DLLVM_ENABLE_ABI_BREAKING_CHECKS=0 -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE=Debug -G "Visual Studio 15 2017" -Thost=x64 ..\llvm
-
-# 64-bit (VS2017)
-$ cmake -DLLVM_ENABLE_ABI_BREAKING_CHECKS=0 -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE=Debug -G "Visual Studio 15 2017" -A x64 -Thost=x64 ..\llvm
-
-# 64-bit (VS2019)
-$ cmake -DLLVM_ENABLE_ABI_BREAKING_CHECKS=0 -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE=Debug -G "Visual Studio 16 2019" -A x64 -Thost=x64 ..\llvm
+# Install
+cmake -P cmake_install.cmake
 ```
 
-### 3. Build for Linux
+### 3. Build for Linux & macOS
 ``` sh
-################################################################################
-# Release                                                                      #
-################################################################################
-# **64-bit**
-$ cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=clang -DLLVM_ENABLE_RTTI=ON -DLLVM_ENABLE_TERMINFO=OFF -G "Unix Makefiles" ../../llvm
-```
+# Config
+cmake -G "Ninja"                              \
+      -DLLVM_ENABLE_ABI_BREAKING_CHECKS=OFF   \
+      -DLLVM_TARGETS_TO_BUILD="X86"           \
+      -DLLVM_ENABLE_PROJECTS="clang;llvm"     \
+      -DCMAKE_BUILD_TYPE=Release              \
+      -DCMAKE_INSTALL_PREFIX="~\llvm\llvm-prebuilt\llvmorg-11.1.0-ninja-gcc-x64-rel"    \
+      ../llvm
 
-### 4. Build for macOS
-``` sh
-################################################################################
-# Release                                                                      #
-################################################################################
-# 64-bit
-$ cmake -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE:STRING=Release -DLLVM_ENABLE_RTTI=1 -G "Unix Makefiles" ../../llvm
+# Make
+cmake --build . --config Release
+
+# Install
+cmake -P cmake_install.cmake
 ```
 
 ➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖

--- a/source/Main.cpp
+++ b/source/Main.cpp
@@ -45,7 +45,7 @@ int main(int Argc, const char **Argv) {
   llvm::sys::fs::make_absolute(AbsSrcPath);
 
   AppCxt.MemoBoard.File.Config       = CheckInputConfig;
-  AppCxt.MemoBoard.File.Source       = AbsSrcPath.str();
+  AppCxt.MemoBoard.File.Source       = AbsSrcPath.str().str();
   AppCxt.MemoBoard.File.OutputJson   = CheckOutputJson;
   AppCxt.MemoBoard.File.LogFile      = LogFile;
   AppCxt.MemoBoard.File.bVerboseMode = VerboseMode;

--- a/source/MyAstConsumer.cpp
+++ b/source/MyAstConsumer.cpp
@@ -23,7 +23,7 @@ bool MyASTConsumer::HandleTopLevelDecl(DeclGroupRef DeclGrpRef) {
     const ASTContext &ASTCxt   = pDecl->getASTContext();
     FullSourceLoc FullLocation = ASTCxt.getFullLoc(pDecl->getBeginLoc());
     if (FullLocation.isValid()) {
-      FileName = FullLocation.getFileLoc().getFileEntry()->getName();
+      FileName = FullLocation.getFileLoc().getFileEntry()->getName().str();
     }
 
     const bool bIsInMainFile = ASTCxt.getSourceManager().isInMainFile(pDecl->getLocation());

--- a/source/MyAstVisitor.cpp
+++ b/source/MyAstVisitor.cpp
@@ -338,7 +338,7 @@ bool MyASTVisitor::VisitEnumConstantDecl(EnumConstantDecl *pDecl) {
   if (!bStatus) {
     string EnumTagName = "???1";
     if (AppCxt.MemoBoard.pLastEnumDecl) {
-      EnumTagName = AppCxt.MemoBoard.pLastEnumDecl->getName();
+      EnumTagName = AppCxt.MemoBoard.pLastEnumDecl->getName().str();
     }
     AppCxt.MemoBoard.Error.nEnum++;
     AppCxt.MemoBoard.ErrorDetailList.push_back(this->createErrorDetail(

--- a/source/MyAstVisitorPriv.cpp
+++ b/source/MyAstVisitorPriv.cpp
@@ -22,7 +22,7 @@ bool MyASTVisitor::getPos(Decl *pDecl, string &FileName, size_t &nLineNumb, size
 
   FullSourceLoc FullLocation = this->m_pAstCxt->getFullLoc(pDecl->getBeginLoc());
   if (FullLocation.isValid()) {
-    FileName = FullLocation.getFileLoc().getFileEntry()->getName();
+    FileName = FullLocation.getFileLoc().getFileEntry()->getName().str();
 
     if ((FileName != AppCxt::getInstance().FileName) || ("" == AppCxt::getInstance().FileName)) {
       AppCxt &AppCxt  = AppCxt::getInstance();


### PR DESCRIPTION
… files which defined in `LLVMConfig.cmake` and `ClangConfig.cmake`. It makes this project can build with specific version of LLVM. I tried those tags, `llvmorg-8.0.0`, `llvmorg-11.1.0` and `llvmorg-12.0.0-rc3`.

Now it build on Windows and Linux platforms only, this is because my MacPro was updated to the latest macOS 10.16(Big Sur) but Azure CI/CD runners support to 10.15 only. So remark to build with macOS on Azure CI/CD temperately. (https://dev.azure.com/HelloClangTool/cppnamelint/_build/results?buildId=60&view=logs&j=1c87aee8-78e4-5a31-daa5-b9cc42aa1a1d)

This PR is going to fix #58 #54 .