### PR TITLE
Fix typo: integrat -> integrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,3 +233,4 @@ MIT
 ## ● Author
 Douglas Chen <dougpuob@gmail.com>
 
+

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The project is a naming convention checking tool executing on Windows/Linux/MacO
 1. Load config file format with TOML.
 1. Output results to console or save an a JSON file.
 1. Support rules with `UpperCamelCase`, `lowerCamelCase`, `UPPER_SNAKE_CASE`, `lower_snake_case`, and `szHungarainNotion`.
-1. Integrat with [Azure DevOps(CI/CD)](https://dev.azure.com/CppNameLint/cpp-namelint/_build?definitionId=3).
+1. Integrate with [Azure DevOps(CI/CD)](https://dev.azure.com/CppNameLint/cpp-namelint/_build?definitionId=3).
 
 ⭐If you like this project or this project gives you some help, please also give me a **STAR** on GitHub, let me know I am not alone.
 


### PR DESCRIPTION
Just found this project from the COSCUP x RubyConfTW 2021 session, and can't help from patching it ;)

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>