### PR TITLE
Fixed wrong command option to call cppnamelint utility in run_util_ch…

### DIFF
--- a/script/cppnamelint.py
+++ b/script/cppnamelint.py
@@ -340,7 +340,7 @@ def run_util_checkdir_files(exec_file_path, py_args, paired_samples:[], print_ou
 
         args_list: [] = ['check', paired['src'], '-config='+paired['cfg']]
         if py_args.json:
-            args_list.append('-jsonfile=' + py_args.json)
+            args_list.append('-jsonout=' + py_args.json)
 
         if py_args.inc:
             for file in py_args.inc:


### PR DESCRIPTION
This issue was filed by @jogardi .